### PR TITLE
Migrate `println!` to `tracing` for structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +107,7 @@ dependencies = [
  "debugging",
  "parsing",
  "strata",
+ "tracing",
 ]
 
 [[package]]
@@ -216,6 +226,9 @@ dependencies = [
 [[package]]
 name = "debugging"
 version = "0.1.0"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "differential-dataflow"
@@ -263,6 +276,8 @@ dependencies = [
  "reading",
  "strata",
  "timely",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -318,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "macros"
 version = "0.1.0"
 dependencies = [
@@ -342,6 +369,15 @@ dependencies = [
  "quote",
  "reading",
  "syn",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -360,6 +396,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,7 +426,14 @@ dependencies = [
  "itertools",
  "parsing",
  "strata",
+ "tracing",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parsing"
@@ -383,6 +442,8 @@ dependencies = [
  "clap",
  "pest",
  "pest_derive",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -436,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "planning"
 version = "0.1.0"
 dependencies = [
@@ -445,6 +512,8 @@ dependencies = [
  "optimizing",
  "parsing",
  "strata",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -478,7 +547,52 @@ dependencies = [
  "serde_json",
  "smallvec",
  "timely",
+ "tracing",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"
@@ -530,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +673,8 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "parsing",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -587,6 +712,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -645,6 +779,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,10 +870,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ smallvec = "1.13.2"
 serde = "1.0.219"
 serde_json = "1.0.140"
 syn = "2.0.104"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 quote = "1.0.40"
 proc-macro2 = "1.0.95"
 paste = "1.0.15"
 mimalloc = "0.1.47"
-
-

--- a/README.md
+++ b/README.md
@@ -101,10 +101,6 @@ FlowLog supports two semiring types for differential dataflow computations:
   <td align="center"><code>-w, --workers &lt;NUM&gt;</code></td>
   <td>Number of threads (default: single core)</td>
 </tr>
-<tr>
-  <td align="center"><code>-v, --verbose</code></td>
-  <td>Enable verbose logging</td>
-</tr>
 <!-- <tr>
   <td align="center"><code>-h, --help</code></td>
   <td>Print help information</td>
@@ -123,8 +119,8 @@ FlowLog supports two semiring types for differential dataflow computations:
 # Run on 16 threads and tab as delimiter
 ./target/release/executing -p ./examples/programs/tc.dl -f ./examples/csvs -d $'\t' -w 16
 
-# Run on verbose output and custom output directory
-./target/release/executing -p ./examples/programs/batik.dl -f ./examples/csvs -c ./results -v
+# Run on debug output and custom output directory
+RUST_LOG=debug ./target/release/executing -p ./examples/programs/batik.dl -f ./examples/csvs -c ./results
 ```
 
 

--- a/env_test.sh
+++ b/env_test.sh
@@ -141,7 +141,7 @@ run_single_test() {
     mkdir -p "$CSV_DIR"
 
     # Run the binary
-    "$BINARY_PATH" \
+    RUST_LOG=info "$BINARY_PATH" \
         --program "$prog_path" \
         --facts "$fact_path" \
         --csvs "$CSV_DIR" \

--- a/env_test.sh
+++ b/env_test.sh
@@ -140,6 +140,9 @@ run_single_test() {
     rm -rf "$CSV_DIR"
     mkdir -p "$CSV_DIR"
 
+    # Print the running command
+    echo "[RUN] Command executing: RUST_LOG=info $BINARY_PATH --program $prog_path --facts $fact_path --csvs $CSV_DIR --workers $WORKERS $sharing_flag"
+
     # Run the binary
     RUST_LOG=info "$BINARY_PATH" \
         --program "$prog_path" \
@@ -147,9 +150,6 @@ run_single_test() {
         --csvs "$CSV_DIR" \
         --workers "$WORKERS" \
         $sharing_flag
-    
-    # Print the running command
-    echo "[RUN] Command executed: $BINARY_PATH --program $prog_path --facts $fact_path --csvs $CSV_DIR --workers $WORKERS --output-result $sharing_flag"
 
     # Verify results
     echo "[VERIFY] Checking results for $test_case..."

--- a/env_test.sh
+++ b/env_test.sh
@@ -146,7 +146,7 @@ run_single_test() {
         --facts "$fact_path" \
         --csvs "$CSV_DIR" \
         --workers "$WORKERS" \
-        --output-result $sharing_flag
+        $sharing_flag
     
     # Print the running command
     echo "[RUN] Command executed: $BINARY_PATH --program $prog_path --facts $fact_path --csvs $CSV_DIR --workers $WORKERS --output-result $sharing_flag"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2021"
 parsing = { path = "../parsing" }  
 strata = { path = "../strata" }  
 debugging = { path = "../debugging" }  
+
+tracing = { workspace = true }

--- a/src/catalog/src/rule.rs
+++ b/src/catalog/src/rule.rs
@@ -4,6 +4,7 @@ use parsing::rule::{Atom, AtomArg, Const, FLRule, Predicate};
 use parsing::head::{Head, HeadArg};
 use crate::atoms::{AtomSignature, AtomArgumentSignature};
 use crate::filters::BaseFilters;
+use tracing::debug;
 
 /* per-rule catalog */
 #[derive(Debug)]
@@ -468,7 +469,7 @@ impl Catalog {
             );
         }
 
-        for r in &sideway_rules { println!("{}", r); }
+        for r in &sideway_rules { debug!("{}", r); }
         sideway_rules
     }
 
@@ -535,7 +536,7 @@ impl Catalog {
         let final_rhs = cores.into_iter().chain(active_neg.into_iter()).chain(cmprs.into_iter()).collect::<Vec<Predicate>>();
 
         let final_rule = FLRule::new(final_head, final_rhs, base_rule.is_planning(), base_rule.is_sip());
-        println!("\nfinal: {}", final_rule);
+        debug!("\nfinal: {}", final_rule);
 
         // construct the final catalog by chaining forward, backward, and the final rule Catalog::from_strata(&final_rule)
         let mut sideways = forward;

--- a/src/debugging/Cargo.toml
+++ b/src/debugging/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tracing = { workspace = true }

--- a/src/debugging/src/debugger.rs
+++ b/src/debugging/src/debugger.rs
@@ -1,22 +1,28 @@
 use std::fmt;
+use tracing::debug;
 
 
-pub fn display_info<T: fmt::Display>(info_title: &str, sub_title: bool, content: T, verbose: bool) {
-    if verbose {
-        let info_title_len = info_title.len();
-        if info_title_len > 0 {
-            if !sub_title {
-                let frame_bound = "-".repeat(info_title_len);
-                println!(
-                    "{}\n{}\n{}\n{}",
-                    frame_bound, info_title, frame_bound, content
-                );
-            } else {
-                println!("-------------------------------- {} --------------------------------\n{}", info_title, content);
-            }
-        } else {
-            println!("{}", content);
-        }
-        println!();
+pub fn display_info<T: fmt::Display>(info_title: &str, sub_title: bool, content: T) {
+    let info_title_len = info_title.len();
+
+    if info_title_len == 0 {
+        debug!("{}\n", content);
+        return;
+    }
+
+    if sub_title {
+        const DASH_COUNT: usize = 32;
+        let left_dashes = "-".repeat(DASH_COUNT);
+        let right_dashes = "-".repeat(DASH_COUNT);
+        debug!(
+            "\n{} {} {}\n{}\n",
+            left_dashes, info_title, right_dashes, content
+        );
+    } else {
+        let frame_bound = "-".repeat(info_title_len);
+        debug!(
+            "\n{}\n{}\n{}\n{}\n",
+            frame_bound, info_title, frame_bound, content
+        );
     }
 }

--- a/src/debugging/src/lib.rs
+++ b/src/debugging/src/lib.rs
@@ -1,16 +1,1 @@
 pub mod debugger;
-
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/executing/Cargo.toml
+++ b/src/executing/Cargo.toml
@@ -31,8 +31,9 @@ macros = { path = "../macros", default-features = false }
 
 clap = { workspace = true, features = ["derive"] }
 itertools = { workspace = true }
-
 timely = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 differential-dataflow = { workspace = true }
 
 # timely = "0.12.0"

--- a/src/executing/src/arg.rs
+++ b/src/executing/src/arg.rs
@@ -19,9 +19,6 @@ pub struct Args {
     #[arg(short, long, default_value_t = false)]
     output_result: bool,
 
-    #[arg(short, long, default_value_t = false)]
-    verbose: bool,
-
     /// delimiter
     #[arg(short, long, default_value = ",")]
     delimiter: String,
@@ -51,10 +48,6 @@ impl Args {
 
     pub fn csvs(&self) -> String {
         (&self.csvs).to_owned()
-    }
-
-    pub fn verbose(&self) -> bool {
-        self.verbose
     }
 
     pub fn output_result(&self) -> bool {

--- a/src/executing/src/arg.rs
+++ b/src/executing/src/arg.rs
@@ -13,11 +13,7 @@ pub struct Args {
 
     /// direct path of the IDBs .csv
     #[arg(short, long)]
-    csvs: String,
-
-    /// evaluate w spilling the output
-    #[arg(short, long, default_value_t = false)]
-    output_result: bool,
+    csvs: Option<String>,
 
     /// delimiter
     #[arg(short, long, default_value = ",")]
@@ -46,12 +42,8 @@ impl Args {
         (&self.facts).to_owned()
     }
 
-    pub fn csvs(&self) -> String {
-        (&self.csvs).to_owned()
-    }
-
-    pub fn output_result(&self) -> bool {
-        self.output_result
+    pub fn csvs(&self) -> Option<String> {
+        self.csvs.clone()
     }
 
     pub fn delimiter(&self) -> &String {

--- a/src/executing/src/arg.rs
+++ b/src/executing/src/arg.rs
@@ -80,10 +80,3 @@ impl Args {
         ]
     }
 }
-
-
-
-pub fn test() {
-    let args = Args::parse();
-    println!("{:?}", args);
-}

--- a/src/executing/src/dataflow.rs
+++ b/src/executing/src/dataflow.rs
@@ -402,14 +402,15 @@ pub fn program_execution(
                         // printsize the relation
                         printsize_generic(&recursive_rel, &format!("[{}]", rel_name), true);
 
-                        // only output if rel is IDBs
-                        if strata.program().idbs().iter().any(|idb| idb.name() == rel_name) {
-                            writesize_generic(&recursive_rel, &rel_name, &format!("{}/size.txt", args.csvs()));
-                            if args.output_result() {
-                                let full_path = format!("{}/{}", args.csvs(), rel_name);
+                        if let Some(csv_path) = args.csvs() {
+                            // only output if rel is IDBs
+                            if strata.program().idbs().iter().any(|idb| idb.name() == rel_name) {
+                                writesize_generic(&recursive_rel, &rel_name, &format!("{}/size.txt", csv_path));
+                                let full_path = format!("{}/{}", csv_path, rel_name);
                                 write_generic(&recursive_rel, &full_path, id);
                             }
                         }
+                        
 
                         // if the rel is in the row_map, it will be overwritten
                         row_map.insert(
@@ -474,9 +475,9 @@ pub fn program_execution(
         if id == 0 {
             info!("{:?}:\tFixpoint reached", timer.elapsed()); // <--- end of clock excluding output
 
-            if args.output_result() {
+            if let Some(csv_path) = args.csvs() {
                 for relation in strata.program().idbs() {
-                    let full_path = format!("{}/{}", args.csvs(), relation.name());
+                    let full_path = format!("{}/{}", csv_path, relation.name());
                     debug!("flusing {} to {}.csv", relation.name(), full_path); // actually merging flushed partitions
                     merge_relation_partitions(&full_path, peers); 
                 }

--- a/src/executing/src/dataflow.rs
+++ b/src/executing/src/dataflow.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::collections::HashMap;
 use itertools::Itertools;
+use tracing::{debug, info};
 
 extern crate timely;
 extern crate differential_dataflow;
@@ -26,8 +27,6 @@ use reading::rel::Rel::*;
 use reading::rel::DoubleRel::*;
 use reading::reader::*; 
 use reading::inspect::*;
-
-
 
 pub fn program_execution(
     args: Args,
@@ -351,7 +350,7 @@ pub fn program_execution(
                         }
 
                         /* concatenate and threshold idbs of the recursive strata into the variables_next_map */
-                        // println!("last_signatures_map: {:?}", group_plan.last_signatures_map());
+                        // debug!("last_signatures_map: {:?}", group_plan.last_signatures_map());
                         recursive_collector(
                             group_plan.last_signatures_map(), 
                             &nest_row_map,
@@ -423,7 +422,7 @@ pub fn program_execution(
         }); 
 
         if id == 0 {
-            println!("{:?}:\tDataflow assembled", timer.elapsed());
+            info!("{:?}:\tDataflow assembled", timer.elapsed());
         }
 
         /* feeding edb data */ 
@@ -459,7 +458,7 @@ pub fn program_execution(
                 .close();
 
             if id == 0 {
-                println!("{:?}:\tData loaded for {}", timer.elapsed(), rel_name);
+                info!("{:?}:\tData loaded for {}", timer.elapsed(), rel_name);
             }
         }
 
@@ -469,12 +468,12 @@ pub fn program_execution(
         }
 
         if id == 0 {
-            println!("{:?}:\tFixpoint reached", timer.elapsed()); // <--- end of clock excluding output
+            info!("{:?}:\tFixpoint reached", timer.elapsed()); // <--- end of clock excluding output
 
             if args.output_result() {
                 for relation in strata.program().idbs() {
                     let full_path = format!("{}/{}", args.csvs(), relation.name());
-                    println!("flusing {} to {}.csv", relation.name(), full_path); // actually merging flushed partitions
+                    debug!("flusing {} to {}.csv", relation.name(), full_path); // actually merging flushed partitions
                     merge_relation_partitions(&full_path, peers); 
                 }
             }

--- a/src/executing/src/dataflow.rs
+++ b/src/executing/src/dataflow.rs
@@ -61,11 +61,10 @@ pub fn program_execution(
             }
 
             /* inspect edbs (optional) */
-            if args.verbose() {
-                for (signature, rel) in row_map
-                    .iter()
-                    .sorted_by_key(|(signature, _)| signature.name()) { printsize_generic(rel, &format!("[{}]", signature.name()), false); }
-            }
+            for (signature, rel) in row_map
+                .iter()
+                .sorted_by_key(|(signature, _)| signature.name()) { printsize_generic(rel, &format!("[{}]", signature.name()), false); }
+            
 
             for group_plan in group_plans.iter() {
                 if !group_plan.is_recursive() {
@@ -171,13 +170,12 @@ pub fn program_execution(
                     );
     
                     /* inspect idbs of the non-recursive strata (optional) */
-                    if args.verbose() {
-                        inspector(
-                            &group_plan.head_signatures_set(), 
-                            &mut row_map,
-                            false
-                        );
-                    }
+                    inspector(
+                        &group_plan.head_signatures_set(), 
+                        &mut row_map,
+                        false
+                    );
+                    
                 } else {
                     let recursive_out_map = scope.iterative::<Iter, _, _>(|scope| {
                         /* (1) construct iterative variables for strata idbs */ 
@@ -358,13 +356,11 @@ pub fn program_execution(
                         );
 
                         /* inspect idbs of the recursive strata (optional) */
-                        if args.verbose() {
-                            inspector(
-                                &head_signatures_set, 
-                                &mut variables_next_map,
-                                true
-                            );
-                        }
+                        inspector(
+                            &head_signatures_set, 
+                            &mut variables_next_map,
+                            true
+                        );
 
                         /* set variables and leave scope */
                         let mut variables_leave_map = HashMap::with_capacity(head_signatures_set.len());

--- a/src/executing/src/dataflow.rs
+++ b/src/executing/src/dataflow.rs
@@ -61,9 +61,13 @@ pub fn program_execution(
             }
 
             /* inspect edbs (optional) */
-            for (signature, rel) in row_map
-                .iter()
-                .sorted_by_key(|(signature, _)| signature.name()) { printsize_generic(rel, &format!("[{}]", signature.name()), false); }
+            if tracing::level_enabled!(tracing::Level::DEBUG) {
+                for (signature, rel) in row_map
+                    .iter()
+                    .sorted_by_key(|(signature, _)| signature.name()) {
+                    printsize_generic(rel, &format!("[{}]", signature.name()), false);
+                }
+            }
             
 
             for group_plan in group_plans.iter() {

--- a/src/executing/src/dataflow.rs
+++ b/src/executing/src/dataflow.rs
@@ -170,11 +170,13 @@ pub fn program_execution(
                     );
     
                     /* inspect idbs of the non-recursive strata (optional) */
-                    inspector(
-                        &group_plan.head_signatures_set(), 
-                        &mut row_map,
-                        false
-                    );
+                    if tracing::level_enabled!(tracing::Level::DEBUG) {
+                        inspector(
+                            &group_plan.head_signatures_set(), 
+                            &mut row_map,
+                            false
+                        );
+                    }
                     
                 } else {
                     let recursive_out_map = scope.iterative::<Iter, _, _>(|scope| {
@@ -356,11 +358,13 @@ pub fn program_execution(
                         );
 
                         /* inspect idbs of the recursive strata (optional) */
-                        inspector(
-                            &head_signatures_set, 
-                            &mut variables_next_map,
-                            true
-                        );
+                        if tracing::level_enabled!(tracing::Level::DEBUG) {
+                            inspector(
+                                &head_signatures_set, 
+                                &mut variables_next_map,
+                                true
+                            );
+                        }
 
                         /* set variables and leave scope */
                         let mut variables_leave_map = HashMap::with_capacity(head_signatures_set.len());

--- a/src/executing/src/main.rs
+++ b/src/executing/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser as ClapParser;
 
 use strata::stratification::Strata;
 use planning::program::ProgramQueryPlan;   
-use reading::FALLBACK_ARITY;
+use reading::{KV_MAX, ROW_MAX};
 use executing::dataflow::program_execution;
 use executing::arg::Args;
 use debugging::debugger;
@@ -14,6 +14,7 @@ use mimalloc::MiMalloc;
 static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
+    /* initialize tracing subscriber for logging */
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
@@ -73,11 +74,11 @@ fn main() {
     );
 
     /* Determine if fat mode should be used based on arity and user preference */
-    let use_fat_mode = program_query_plan.should_use_fat_mode(args.fat_mode(), FALLBACK_ARITY);
+    let use_fat_mode = program_query_plan.should_use_fat_mode(args.fat_mode(), KV_MAX, ROW_MAX);
     
     /* If fat mode was forced due to high arity, inform the user */
     if use_fat_mode && !args.fat_mode() {
-        warn!("WARNING: Fat mode automatically enabled due to high arity (> {})", FALLBACK_ARITY);
+        warn!("WARNING: Fat mode automatically enabled due to high arity");
         warn!("         Maximal incomparable arity pairs found: {:?}", program_query_plan.maximal_arity_pairs());
     }
     

--- a/src/optimizing/Cargo.toml
+++ b/src/optimizing/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-itertools = { workspace = true }
 parsing = { path = "../parsing" }  
 strata = { path = "../strata" }  
 catalog = { path = "../catalog" }  
 debugging = { path = "../debugging" }  
+
+itertools = { workspace = true }
+tracing = { workspace = true }

--- a/src/optimizing/src/optimizer.rs
+++ b/src/optimizing/src/optimizer.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::{collections::{BinaryHeap, HashMap, HashSet}, vec};
 use std::cmp::Reverse;
 use catalog::rule::Catalog;
+use tracing::debug;
 
 // assuming no cross products for the joins
 
@@ -179,7 +180,7 @@ impl PlanTree {
                         // add the child to the parent (there must be one)
                         candidate_tree.get_mut(&parent_id).unwrap().push(child_id);
                         candidate_tree.insert(child_id, vec![]);
-                        // println!("insert edge ({} -> {})", parent_id, child_id);
+                        // debug!("insert edge ({} -> {})", parent_id, child_id);
                         candidate_overlap += prev_overlap;
                     }
 
@@ -215,7 +216,7 @@ impl PlanTree {
                     let candidate_depth = Self::populate_tree_depth(candidate_root, &candidate_tree);
 
                     if candidate_width < width || (candidate_width == width && candidate_depth < depth) {
-                        println!("newly optimized tree found w/ width {} and depth {}", candidate_width, candidate_depth);
+                        debug!("newly optimized tree found w/ width {} and depth {}", candidate_width, candidate_depth);
                         tree = candidate_tree;
                         width = candidate_width;
                         depth = candidate_depth;

--- a/src/parsing/Cargo.toml
+++ b/src/parsing/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 clap = { workspace = true, features = ["derive"] }
 pest = { workspace = true }
 pest_derive = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/src/parsing/src/decl.rs
+++ b/src/parsing/src/decl.rs
@@ -122,8 +122,8 @@ impl Lexeme for RelDecl {
         /* parsing the relation name */
         let name = parsed_rule.next().unwrap().as_str(); // as_str() returns the original string of the input
 
-        // println!(".decl name = {:?}", name);
-        // println!("RelDecl attributes = {:?}", parsed_rule);
+        // debug!(".decl name = {:?}", name);
+        // debug!("RelDecl attributes = {:?}", parsed_rule);
 
         /* parsing the relation attributes */
         let attributes = parsed_rule
@@ -131,7 +131,7 @@ impl Lexeme for RelDecl {
             .unwrap()
             .into_inner()
             .map(|attr| {
-                // println!(".decl attribute = {:?}", attr);
+                // debug!(".decl attribute = {:?}", attr);
                 let mut attr = attr.into_inner();
                 let name = attr.next().unwrap().as_str();
                 let data_type = attr.next().unwrap().as_str();

--- a/src/parsing/src/main.rs
+++ b/src/parsing/src/main.rs
@@ -1,8 +1,16 @@
 use parsing::parser::Lexeme;
 use parsing::{FlowLogParser, Parser, Rule};
 use std::fs;
+use tracing::{info, debug};
+use tracing_subscriber::EnvFilter;
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     let program_source = "./examples/programs/greater_equal.dl";
     let unparsed_str = fs::read_to_string(program_source)
         .unwrap_or_else(|_| panic!("can't read program from \"{}\"", program_source));
@@ -23,12 +31,12 @@ fn main() {
     // print_rule(parsed_rule, 0); // print the parsed rule
     // print_rule_as_tree(parsed_rule, 0, true); // print the parsed rule as a tree
    
-    println!(
+    debug!(
         "{}",
         parsing::parser::Program::from_parsed_rule(parsed_rule)
     );
 
-    println!("success parse");
+    info!("success parse");
 }
 
 // fn print_rule(rule: pest::iterators::Pair<Rule>, depth: usize) {
@@ -37,7 +45,7 @@ fn main() {
 //     let rule_span = rule.as_span();              // returns a span of the input string
 //     let rule_str = rule_span.as_str();           // returns a string slice of the input string
 
-//     println!("{}{:?} >> {}", indent, rule_name, rule_str); 
+//     debug!("{}{:?} >> {}", indent, rule_name, rule_str); 
     
 //     rule.into_inner()
 //         .for_each(|rule| print_rule(rule, depth + 1));
@@ -58,9 +66,9 @@ fn main() {
 
 //     // print the rule with tree structure
 //     if rule_str.len() > 240 {
-//         println!("{}{} >> ({:.240}...)", indent, rule_name, rule_str);
+//         debug!("{}{} >> ({:.240}...)", indent, rule_name, rule_str);
 //     } else {
-//         println!("{}{} >> ({})", indent, rule_name, rule_str);
+//         debug!("{}{} >> ({})", indent, rule_name, rule_str);
 //     }
 
 //     // transform into inner pairs and print them as part of the tree

--- a/src/parsing/src/rule.rs
+++ b/src/parsing/src/rule.rs
@@ -2,6 +2,8 @@ use crate::{head::Head, parser::Lexeme, Rule};
 use pest::iterators::Pair;
 use crate::compare::ComparisonExpr;
 use std::fmt;
+use tracing::error;
+
 
 /*
     Atom: NAME(AtomArg, AtomArg, ...)
@@ -89,7 +91,7 @@ impl Lexeme for Const {
         match inner.as_rule() {
             Rule::integer => Self::Integer(inner.as_str().parse::<i32>().unwrap()),
             Rule::string => Self::Text(inner.as_str().to_string()),
-            _ => { println!("constant parsing panic {:?}", inner); unreachable!() }
+            _ => { error!("constant parsing panic {:?}", inner); unreachable!() }
         }
     }
 }

--- a/src/planning/Cargo.toml
+++ b/src/planning/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 itertools = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 parsing = { path = "../parsing" }  
 strata = { path = "../strata" }  

--- a/src/planning/src/flow.rs
+++ b/src/planning/src/flow.rs
@@ -186,8 +186,8 @@ impl TransformationFlow {
         output_value_signatures: &Vec<AtomArgumentSignature>,
         compare_exprs: &Vec<ComparisonExprPos>  
     ) -> Self {
-        // println!("input_left_key_signatures: {:?}", input_left_key_signatures);
-        // println!("input_right_key_signatures: {:?}", input_right_key_signatures);
+        // debug!("input_left_key_signatures: {:?}", input_left_key_signatures);
+        // debug!("input_right_key_signatures: {:?}", input_right_key_signatures);
         
         let left_signature_map = Self::kv_argument_flow_map(input_left_key_signatures, input_left_value_signatures)
             .into_iter()

--- a/src/planning/src/main.rs
+++ b/src/planning/src/main.rs
@@ -1,12 +1,20 @@
 use parsing::parser::Lexeme;
 use parsing::{FlowLogParser, Parser, Rule};
 use std::fs;
+use tracing::{info};
 
 use strata::stratification::Strata;
 use planning::program::ProgramQueryPlan;   
+use tracing_subscriber::EnvFilter;
 // use strata::dependencies::DependencyGraph;
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     let program_source = "./examples/programs/ddisasm-test.dl";
     let unparsed_str = fs::read_to_string(program_source)
         .unwrap_or_else(|_| panic!("can't read program from \"{}\"", program_source));
@@ -32,7 +40,6 @@ fn main() {
         "Strata (Topological Order)",
         true,
         format!("{}\n", strata),
-        true
     );
 
     // planning
@@ -41,8 +48,7 @@ fn main() {
     debugging::debugger::display_info(
         "Program Query Plans", 
         true, 
-        format!("{}", program_query_plan), 
-        true);
+        format!("{}", program_query_plan));
 
     /* arity analysis */
     debugging::debugger::display_info(
@@ -57,8 +63,7 @@ fn main() {
                 .collect::<Vec<_>>()
                 .join("\n")
         ),
-        true
     );
 
-    println!("success planning");
+    info!("success planning");
 }

--- a/src/planning/src/program.rs
+++ b/src/planning/src/program.rs
@@ -158,13 +158,13 @@ impl ProgramQueryPlan {
     }
 
     /// Determines if fat mode should be used based on the maximum arity required.
-    /// Fat mode is REQUIRED for arities > fallback_arity (usually 3 or 8),
+    /// Fat mode is REQUIRED for arities > fallback_arity 
     /// as the fixed-size array implementations only support up to this arity.
-    pub fn should_use_fat_mode(&self, user_requested_fat_mode: bool, fallback_arity: usize) -> bool {
+    pub fn should_use_fat_mode(&self, user_requested_fat_mode: bool, fallback_key: usize, fallback_value: usize) -> bool {
         // If any key or value arity exceeds fallback_arity, fat mode must be used
         // Otherwise, it depends on the user's command-line argument
         let maximal_pairs = self.maximal_arity_pairs();
-        let any_exceeds_fallback = maximal_pairs.iter().any(|(k, v)| *k > fallback_arity || *v > fallback_arity);
+        let any_exceeds_fallback = maximal_pairs.iter().any(|(k, v)| *k > fallback_key || *v > fallback_value);
         any_exceeds_fallback || user_requested_fat_mode
     }
 

--- a/src/planning/src/program.rs
+++ b/src/planning/src/program.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 // use itertools::Itertools;
 use std::collections::HashSet;
+use tracing::debug;
 
 // use parsing::rule::FLRule;
 use strata::stratification::Strata;
@@ -61,8 +62,8 @@ impl ProgramQueryPlan {
 
         // debugging for each rule plan in the group
         for (is_recursive, rule_plans) in &rule_plans {
-            println!("-------------------------------- {} strata group --------------------------------", if *is_recursive { "recursive" } else { "non-recursive" });
-            for rule_plan in rule_plans { println!("{}", rule_plan); }
+            debug!("-------------------------------- {} strata group --------------------------------", if *is_recursive { "recursive" } else { "non-recursive" });
+            for rule_plan in rule_plans { debug!("{}", rule_plan); }
         }
 
         // accumulative seen seet across all strata

--- a/src/planning/src/rule.rs
+++ b/src/planning/src/rule.rs
@@ -37,7 +37,7 @@ impl RuleQueryPlan {
     /* main entry */
     pub fn from_catalog(catalog: &Catalog, is_optimized: bool) -> Self {
         let plan = PlanTree::from_catalog(catalog, is_optimized);   
-        // println!("join spanning tree: {:?}", plan);
+        // debug!("join spanning tree: {:?}", plan);
         let mut is_active_negation_bitmap = vec![true; catalog.negated_atom_names().len()];
 
         // a vector of length catalog.atom_names().len()
@@ -216,9 +216,9 @@ impl RuleQueryPlan {
                 }   
             }
 
-            // println!("join key arguments: {:?}", join_key_strs);
-            // println!("leftover value arguments: {:?}", leftover_value_strs);
-            // println!("planning value arguments: {:?}", planning_value_strs);
+            // debug!("join key arguments: {:?}", join_key_strs);
+            // debug!("leftover value arguments: {:?}", leftover_value_strs);
+            // debug!("planning value arguments: {:?}", planning_value_strs);
             
             /* ------------------------------------ recursive calls ------------------------------------ */
             // clone the original tree and remove the last child from the entry for the root
@@ -253,7 +253,7 @@ impl RuleQueryPlan {
             /* ------------------------------------ end of recursive calls ------------------------------------ */
 
             // for &comp_id in &join_comp_ids {
-            //     println!("join filters to be fused: {}", catalog.comparison_predicates()[comp_id]);
+            //     debug!("join filters to be fused: {}", catalog.comparison_predicates()[comp_id]);
             // }
         
             /* ------------------------------------ final join (follow by one or more antijoins) transformations ------------------------------------ */
@@ -538,7 +538,7 @@ impl RuleQueryPlan {
                 );
             
             // for compare_expr_signature in &compare_expr_signatures {
-            //     println!("comparison signatures for {}: {}", negated_atom_signature, compare_expr_signature);
+            //     debug!("comparison signatures for {}: {}", negated_atom_signature, compare_expr_signature);
             // }
                     
             let (left_transformation, mut tree) =
@@ -577,7 +577,7 @@ impl RuleQueryPlan {
                     &catalog.top_down_trace(&head_value_arguments, planning_atom_signatures),
                 );
 
-            // println!("antijoin inserted: {}", root_transformation.flow());
+            // debug!("antijoin inserted: {}", root_transformation.flow());
 
             tree.insert(
                 root_transformation.clone(),
@@ -622,7 +622,7 @@ impl RuleQueryPlan {
             assert!(active_comparison_predicates.len() == compare_expr_signatures.len(), "active comparisons for semijoins are not fully consumed by the base"); 
 
             // for compare_expr_signature in &compare_expr_signatures {
-            //     println!("comparison signatures for {}: {}", planning_atom_signature, compare_expr_signature);
+            //     debug!("comparison signatures for {}: {}", planning_atom_signature, compare_expr_signature);
             // }
             
             let leaf_transformation = Transformation::kv_to_kv(
@@ -680,7 +680,7 @@ impl RuleQueryPlan {
                 );
             
             // for compare_expr_signature in &compare_expr_signatures {
-            //     println!("comparison signatures for {}: {}", subatom_signature, compare_expr_signature);
+            //     debug!("comparison signatures for {}: {}", subatom_signature, compare_expr_signature);
             // }
 
             let (left_transformation, mut tree) = Self::recursive_semijoins(

--- a/src/planning/src/strata.rs
+++ b/src/planning/src/strata.rs
@@ -112,13 +112,13 @@ impl GroupStrataQueryPlan {
         // base case (already seen) - skip if sharing is disabled
         if !disable_sharing && seen.contains(output_signature) {
             // it can't be the that global scope has an intermediate rel that is produced by some recursive idb of this strata (we can safely reuse it)
-            // println!("borrow {} from global", output_signature);
+            // debug!("borrow {} from global", output_signature);
             return (vec![], HashSet::from([Arc::clone(&output_signature)]));
         }
 
         // base case (already nested_seen) - skip if sharing is disabled
         if !disable_sharing && nested_seen.contains(output_signature) {
-            // println!("borrow {} from nested", output_signature);
+            // debug!("borrow {} from nested", output_signature);
             return (vec![], HashSet::new());
         }
 

--- a/src/reading/Cargo.toml
+++ b/src/reading/Cargo.toml
@@ -23,3 +23,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 arrayvec = { workspace = true, features = ["serde"] }
 paste = { workspace = true }
+tracing = { workspace = true }

--- a/src/reading/examples/check_config.rs
+++ b/src/reading/examples/check_config.rs
@@ -24,17 +24,8 @@ fn main() {
     
     // Configuration parameters
     println!("--- Configuration Parameters ---");
-    println!("FALLBACK_ARITY: {} (max arity before using fat mode)", FALLBACK_ARITY);
+    println!("FALLBACK_ARITY: {} (max arity before forcing fat mode)", FALLBACK_ARITY);
     println!("KV_MAX: {} (max arity for key-value operations)", KV_MAX);
     println!("ROW_MAX: {} (max arity for row operations)", ROW_MAX);
     println!("PROD_MAX: {} (max arity for product operations)", PROD_MAX);
-    
-    println!();
-    
-    // Feature summary
-    println!();
-    println!("--- Build Configuration Summary ---");
-    println!("Semiring: {} ({} bytes)", SEMIRING_TYPE, std::mem::size_of::<reading::Semiring>());
-    println!("Max fixed arity: {}", FALLBACK_ARITY);
-    println!("Codegen limits: KV={}, ROW={}, PROD={}", KV_MAX, ROW_MAX, PROD_MAX);
 }

--- a/src/reading/src/config.rs
+++ b/src/reading/src/config.rs
@@ -4,16 +4,16 @@
 //! for various operations in the FlowLog engine.
 
 /// Maximum arity for key-value in code generation
-pub const KV_MAX: usize = 2;
+pub const KV_MAX: usize = 6;
 
 /// Maximum arity for row in code generation  
-pub const ROW_MAX: usize = 2;
+pub const ROW_MAX: usize = 8;
 
 /// Maximum arity for product in code generation
 pub const PROD_MAX: usize = 2;
 
 /// Maximum arity before falling back to fat representations
-pub const FALLBACK_ARITY: usize = KV_MAX;
+pub const FALLBACK_ARITY: usize = ROW_MAX;
 
 /// Configuration for compile-time code generation limits
 pub struct CodegenLimits;

--- a/src/reading/src/config.rs
+++ b/src/reading/src/config.rs
@@ -24,25 +24,3 @@ impl CodegenLimits {
     pub const PROD_MAX: usize = PROD_MAX;
     pub const FALLBACK_ARITY: usize = FALLBACK_ARITY;
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    
-    #[test]
-    fn test_config_consistency() {
-        // ensure the limits make sense relative to fallback arity
-        assert!(KV_MAX <= FALLBACK_ARITY);
-        assert!(ROW_MAX <= FALLBACK_ARITY);
-        assert!(PROD_MAX <= FALLBACK_ARITY);
-    }
-    
-    #[test]
-    fn test_config_values() {
-        // verify expected values
-        // assert_eq!(FALLBACK_ARITY, 8);
-        // assert_eq!(KV_MAX, 2);
-        // assert_eq!(ROW_MAX, 2);
-        // assert_eq!(PROD_MAX, 2);
-    }
-}

--- a/src/reading/src/inspect.rs
+++ b/src/reading/src/inspect.rs
@@ -254,7 +254,10 @@ pub fn merge_relation_partitions(output_path: &str, worker_count: usize) {
             match read_to_string(&part_path) {
                 Ok(content) => Some(content),
                 Err(_) => {
-                    error!("Warning: missing or unreadable file {}", part_path);
+                    if worker_id == 0 {
+                        // log an error
+                        error!("Warning: missing or unreadable file {}", part_path);
+                    }
                     None
                 }
             }

--- a/src/reading/src/inspect.rs
+++ b/src/reading/src/inspect.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use timely::dataflow::Scope;
 use timely::order::TotalOrder;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::rel::Rel;
 use crate::semiring_one;
@@ -69,7 +69,7 @@ where
         .lift(|_| Some(((), 1 as i32)))
         .map(|_| ())
         .consolidate()
-        .inspect(move |x| debug!("{}: {:?}", prefix, x));
+        .inspect(move |x| info!("{}: {:?}", prefix, x));
 }
 
 /// Prints the content of a relation (all tuples)

--- a/src/reading/src/reader.rs
+++ b/src/reading/src/reader.rs
@@ -12,6 +12,8 @@ use differential_dataflow::operators::iterate::SemigroupVariable;
 use timely::dataflow::Scope;
 use timely::order::Product;
 
+use tracing::debug;
+
 use parsing::decl::RelDecl;
 use crate::row::Row;
 use crate::row::FatRow;
@@ -56,7 +58,7 @@ macro_rules! generate_read_row_functions {
                     let rel_arity = rel_decl.arity();
 
                     if id == 0 {
-                        println!("reading {} from {}", rel_decl, rel_path);
+                        debug!("reading {} from {}", rel_decl, rel_path);
                     }
 
                     let ingest = 

--- a/src/reading/src/reader.rs
+++ b/src/reading/src/reader.rs
@@ -208,7 +208,7 @@ macro_rules! generate_read_row_generic {
                             [<read_row_ $n>](rel_decl, rel_path, delimiter, &mut session_generic.[<listen_ $n>](), id, peers)
                         },
                     )*
-                    _ => unreachable!("arity {} should be handled by match arms if <= MAX_FALLBACK_ARITY", arity),
+                    _ => unreachable!("arity {} should be handled by match arms if <= MAX_ROW_ARITY", arity),
                 }
             } else {
                 // fat mode
@@ -241,7 +241,7 @@ macro_rules! generate_construct_var {
                             Rel::[<Variable $n>](SemigroupVariable::<_, Row<$n>, Semiring>::new(scope, Product::new(Default::default(), 1)))
                         },
                     )*
-                    _ => unreachable!("arity {} should be handled by match arms if <= MAX_FALLBACK_ARITY", arity),
+                    _ => unreachable!("arity {} should be handled by match arms if <= MAX_ROW_ARITY", arity),
                 }
             } else {
                 // fat mode

--- a/src/strata/Cargo.toml
+++ b/src/strata/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2021"
 
 [dependencies]
 parsing = { path = "../parsing" }  
+
 itertools = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/src/strata/src/dependencies.rs
+++ b/src/strata/src/dependencies.rs
@@ -31,7 +31,7 @@ impl DependencyGraph {
         let rules = program.rules();
         let rule_idb_names = rules.iter().map(|rule| rule.head().name().clone()).collect::<Vec<String>>();
         
-        // println!(".depgraph rule_idb_names = {:?}", rule_idb_names);
+        // debug!(".depgraph rule_idb_names = {:?}", rule_idb_names);
 
         /* head2rule_ids_map maps head_name to rule_ids of that head */ 
         let mut head2rule_ids_map = HashMap::new();

--- a/src/strata/src/main.rs
+++ b/src/strata/src/main.rs
@@ -1,11 +1,19 @@
 use parsing::parser::Lexeme;
 use parsing::{FlowLogParser, Parser, Rule};
 use std::fs;
+use tracing::{debug, info};
 
 use strata::stratification::Strata;
+use tracing_subscriber::EnvFilter;
 // use analyzing::dependencies::DependencyGraph;
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     let program_source = "./examples/programs/cspa.dl";
     let unparsed_str = fs::read_to_string(program_source)
         .unwrap_or_else(|_| panic!("can't read program from \"{}\"", program_source));
@@ -31,8 +39,8 @@ fn main() {
     // let graph = DependencyGraph::from_program(&program);
     let strata = Strata::from_parser(program);
     
-    println!("{}", strata.dependency_graph());
-    println!("{}", strata);
+    debug!("{}", strata.dependency_graph());
+    debug!("{}", strata);
 
-    println!("success parse");
+    info!("success parse");
 }

--- a/src/strata/src/stratification.rs
+++ b/src/strata/src/stratification.rs
@@ -165,7 +165,7 @@ impl Strata {
                       .collect()
             })
             .collect();
-        // println!("strata_dependencies: {:?}", strata_dependencies);
+        // debug!("strata_dependencies: {:?}", strata_dependencies);
 
         let mut merged = vec![false; strata.len()];
         let mut mergers = Vec::new();
@@ -177,7 +177,7 @@ impl Strata {
             for (i, s) in strata.iter().enumerate() {
                 if !merged[i] && strata_dependencies[i].is_empty() { // not yet merged and no dependencies
                     merged[i] = true;
-                    // println!("merging stratum: {:?}", s);
+                    // debug!("merging stratum: {:?}", s);
                     if is_recursive_strata_bitmap[i] {
                         next_recursive.push(s.clone()); // batch non-recursive strata
                     } else {
@@ -194,8 +194,8 @@ impl Strata {
                 );
             }
 
-            // println!("next non-recursive strata: {:?}", next_non_recursive);
-            // println!("next recursive strata: {:?}", next_recursive);
+            // debug!("next non-recursive strata: {:?}", next_non_recursive);
+            // debug!("next recursive strata: {:?}", next_recursive);
             
             if !next_non_recursive.is_empty() { 
                 mergers.push(next_non_recursive); 
@@ -208,7 +208,7 @@ impl Strata {
             }
         }
 
-        // println!("merged strata: {:?}", mergers);
+        // debug!("merged strata: {:?}", mergers);
         // --------------------------------------------------------------------------- //
             
         Self {


### PR DESCRIPTION
- Added tracing and tracing-subscriber
- Initialized subscriber with env filter (default to info)
- Replaced `println!` with `info!`, `error!`, `debug!`
- Logs can be filtered with `RUST_LOG`

Code example
```rust
use tracing::{info, error, debug};
use tracing_subscriber::{fmt, EnvFilter};

fn main() {
    fmt()
        .with_env_filter(
            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
        )
        .init();

    info!("Program started.");
    // println!("Program started.");

    let filename = "example.txt";
    info!("Loading file: {}", filename);
    // println!("Loading file: {}", filename);

    let err = "File not found";
    error!("Error occurred: {}", err);
    // println!("Error occurred: {}", err);

    debug!("Debugging details here...");
    // println!("Debugging details here...");
}
```

